### PR TITLE
Add sort functionality and stop using indicies

### DIFF
--- a/src/app/browse/browse.component.html
+++ b/src/app/browse/browse.component.html
@@ -3,23 +3,23 @@
     <app-search (newValue)="searchSongs($event)"></app-search>
   </div>
   <div>
-    <app-sort [sortOptions]="sortOptions"></app-sort>
+    <app-sort [sortOptions]="sortOptions" (optionSelected)="sortSongs($event)"></app-sort>
   </div>
 </div>
 <div *ngIf="!isSearching">
   <h1>TRENDING</h1>
   <div class="responsive-row">
-    <app-card *ngFor="let index of trending" [songData]="allSongs[index]"></app-card>
+    <app-card *ngFor="let song of trending" [songData]="song"></app-card>
   </div>
   <h1>JUST ADDED</h1>
   <div class="responsive-row">
-    <app-card *ngFor="let index of justAdded" [songData]="allSongs[index]"></app-card>
+    <app-card *ngFor="let song of justAdded" [songData]="song"></app-card>
   </div>
 </div>
 <div *ngIf="isSearching">
   <h1>SEARCH</h1>
   <div class="responsive-row">
-    <app-card *ngFor="let index of searchedSongs" [songData]="allSongs[index]"></app-card>
+    <app-card *ngFor="let song of searchedSongs" [songData]="song"></app-card>
   </div>
   <p *ngIf="!searchedSongs.length">No results</p>
 </div>

--- a/src/app/browse/browse.component.spec.ts
+++ b/src/app/browse/browse.component.spec.ts
@@ -3,29 +3,30 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BrowseComponent } from './browse.component';
 import { BrowseService } from './browse.service';
+import { SongData } from '../data_and_interfaces/song-data';
 
 describe('BrowseComponent', () => {
   let component: BrowseComponent;
   let fixture: ComponentFixture<BrowseComponent>;
-  const mockGetAllSongsValue = [{}, {}];
-  const mockGetTrendingIndicies = [0];
-  const mockGetJustAddedIndicies = [1];
+  const mockGetTrendingSongs = [SongData[0]];
+  const mockGetJustAddedSongs = [SongData[1]];
+  let browseService: BrowseService;
 
   class MockBrowseService {
-    getAllSongs() {
-      return mockGetAllSongsValue;
+    getTrendingSongs() {
+      return mockGetTrendingSongs;
     }
 
-    getTrendingIndicies() {
-      return mockGetTrendingIndicies;
+    getJustAddedSongs() {
+      return mockGetJustAddedSongs;
     }
 
-    getJustAddedIndicies() {
-      return mockGetJustAddedIndicies;
+    getMatchingSongs() {
+      return mockGetTrendingSongs;
     }
 
-    getMatchingSongIndicies() {
-      return mockGetTrendingIndicies;
+    sortByOption(songs, option) {
+      return songs;
     }
   }
 
@@ -42,12 +43,12 @@ describe('BrowseComponent', () => {
     fixture = TestBed.createComponent(BrowseComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    browseService = fixture.debugElement.injector.get(BrowseService);
   });
 
-  it('should have allSongs, trending, and justAdded populatd', () => {
-    expect(component.allSongs).toEqual(<any>mockGetAllSongsValue);
-    expect(component.trending).toEqual(mockGetTrendingIndicies);
-    expect(component.justAdded).toEqual(mockGetJustAddedIndicies);
+  it('should have trending and justAdded populatd', () => {
+    expect(component.trending).toEqual(mockGetTrendingSongs);
+    expect(component.justAdded).toEqual(mockGetJustAddedSongs);
   });
 
   it('should call searchSongs without an input and have isSearching set to false', () => {
@@ -58,6 +59,12 @@ describe('BrowseComponent', () => {
   it('should call searchSongs with an input and have isSearching set to true', () => {
     component.searchSongs('test');
     expect(component.isSearching).toBe(true);
-    expect(component.searchedSongs).toEqual(mockGetTrendingIndicies);
+    expect(component.searchedSongs).toEqual(mockGetTrendingSongs);
+  });
+
+  it('should call softSongs and call the service 3 times', () => {
+    const sortByOptionSpy = spyOn(browseService, 'sortByOption');
+    component.sortSongs(0);
+    expect(sortByOptionSpy).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/app/browse/browse.component.ts
+++ b/src/app/browse/browse.component.ts
@@ -10,26 +10,33 @@ import { Song } from '../data_and_interfaces/song.interface';
 })
 export class BrowseComponent implements OnInit {
   sortOptions = ['Newest', 'Easiest', 'Hardest'];
-  allSongs: Song[];
-  trending: number[];
-  justAdded: number[];
-  searchedSongs: number[];
+  trending: Song[];
+  justAdded: Song[];
+  searchedSongs = [];
   isSearching = false;
 
   constructor(private browseService: BrowseService) { }
 
   ngOnInit() {
-    this.allSongs = this.browseService.getAllSongs();
-    this.trending = this.browseService.getTrendingIndicies();
-    this.justAdded = this.browseService.getJustAddedIndicies();
+    this.trending = this.browseService.getTrendingSongs();
+    this.justAdded = this.browseService.getJustAddedSongs();
+    this.sortSongs(0);
   }
 
-  searchSongs(searchQuery: string) {
+  searchSongs(searchQuery: string): void {
     if (!searchQuery) {
       this.isSearching = false;
       return;
     }
     this.isSearching = true;
-    this.searchedSongs = this.browseService.getMatchingSongIndicies(searchQuery, this.allSongs);
+    const allSongs = this.trending.concat(this.justAdded);
+    this.searchedSongs = this.browseService.getMatchingSongs(searchQuery, allSongs);
+  }
+
+  sortSongs(sortIndex: number) {
+    const sortOption = this.sortOptions[sortIndex];
+    this.trending = this.browseService.sortByOption(this.trending, sortOption);
+    this.justAdded = this.browseService.sortByOption(this.justAdded, sortOption);
+    this.searchedSongs = this.browseService.sortByOption(this.searchedSongs, sortOption);
   }
 }

--- a/src/app/browse/browse.service.spec.ts
+++ b/src/app/browse/browse.service.spec.ts
@@ -15,37 +15,68 @@ describe('BrowseService', () => {
     service = browseService;
   }));
 
-  it('should return SongData when calling getAllSongs', () => {
-    expect(service.getAllSongs()).toBe(SongData);
+  it('should return the first two songs for getTrendingSongs', () => {
+    expect(service.getTrendingSongs()).toEqual([SongData[0], SongData[1]]);
   });
 
-  it('should return [0, 1] for getTrendingIndicies', () => {
-    expect(service.getTrendingIndicies()).toEqual([0, 1]);
-  });
-
-  it('should return 2-the rest of the songs for for getJustAddedIndicies', () => {
+  it('should return 2-the rest of the songs for for getJustAddedSongs', () => {
     const trendingIndicies = [];
     for (let i = 2; i < SongData.length; i++) {
-      trendingIndicies.push(i);
+      trendingIndicies.push(SongData[i]);
     }
-    expect(service.getJustAddedIndicies()).toEqual(trendingIndicies);
+    expect(service.getJustAddedSongs()).toEqual(trendingIndicies);
   });
 
   it('should return [0] if only the first song matches', () => {
     const mockSong = {title: 'test'};
-    const result = service.getMatchingSongIndicies('st', <any>[mockSong]);
-    expect(result).toEqual([0]);
+    const result = service.getMatchingSongs('st', <any>[mockSong]);
+    expect(result).toEqual(<any>[mockSong]);
   });
 
   it('should return [] for a song that doesn\'t match', () => {
     const mockSong = {title: 'test'};
-    const result = service.getMatchingSongIndicies('tt', <any>[mockSong]);
+    const result = service.getMatchingSongs('tt', <any>[mockSong]);
     expect(result).toEqual([]);
   });
 
   it('should return [1] for a song that matches the artist name', () => {
     const mockSongs = [{title: 'test'}, {title: 'no', artist: {name: 'MaTcH'}}];
-    const result = service.getMatchingSongIndicies('mAtCh', <any>mockSongs);
-    expect(result).toEqual([1]);
+    const result = service.getMatchingSongs('mAtCh', <any>mockSongs);
+    expect(result).toEqual(<any>[mockSongs[1]]);
+  });
+
+  it('should sort songs newest to oldest', () => {
+    const oldSong = {createdAt: '2015-12-02T18:08:26.103Z'};
+    const newSong = {createdAt: '2017-12-02T18:08:26.103Z'};
+    const mockSongs = [oldSong, newSong];
+    const result = service.sortByOption(<any>mockSongs, 'NEwEst');
+    expect(result).toEqual(<any>[newSong, oldSong]);
+  });
+
+  it('should sort songs easiest to hardest', () => {
+    const easySong = {difficultyId: 1};
+    const mediumSong = {difficultyId: 2};
+    const hardSong = {difficultyId: 3};
+    const mockSongs = [mediumSong, hardSong, easySong];
+    const result = service.sortByOption(<any>mockSongs, 'EaSIEst');
+    expect(result).toEqual(<any>[easySong, mediumSong, hardSong]);
+  });
+
+  it('should sort songs hardest to easiest', () => {
+    const easySong = {difficultyId: 1};
+    const mediumSong = {difficultyId: 2};
+    const hardSong = {difficultyId: 3};
+    const mockSongs = [mediumSong, easySong, hardSong];
+    const result = service.sortByOption(<any>mockSongs, 'HArdeSt');
+    expect(result).toEqual(<any>[hardSong, mediumSong, easySong]);
+  });
+
+  it('should just return the array if invalid option', () => {
+    const easySong = {difficultyId: 1};
+    const mediumSong = {difficultyId: 2};
+    const hardSong = {difficultyId: 3};
+    const mockSongs = [mediumSong, easySong, hardSong];
+    const result = service.sortByOption(<any>mockSongs, 'iNvaLid');
+    expect(result).toEqual(<any>[mediumSong, easySong, hardSong]);
   });
 });

--- a/src/app/browse/browse.service.ts
+++ b/src/app/browse/browse.service.ts
@@ -8,34 +8,47 @@ export class BrowseService {
 
   constructor() { }
 
-  getAllSongs(): Song[] {
-    return SongData;
+  getTrendingSongs(): Song[] {
+    return [SongData[0], SongData[1]];
   }
 
-  getTrendingIndicies(): number[] {
-    return [0, 1];
-  }
-
-  getJustAddedIndicies(): number[] {
-    const trendingIndicies = [];
-    for (let i = 2; i < this.getAllSongs().length; i++) {
-      trendingIndicies.push(i);
+  getJustAddedSongs(): Song[] {
+    const justAddedSongs = [];
+    for (let i = 2; i < SongData.length; i++) {
+      justAddedSongs.push(SongData[i]);
     }
-    return trendingIndicies;
+    return justAddedSongs;
   }
 
-  getMatchingSongIndicies(searchQuery: string, songs: Song[]): number[] {
-    const songIndicies = [];
+  getMatchingSongs(searchQuery: string, songs: Song[]): Song[] {
+    const matchedSongs = [];
     for (let i = 0; i < songs.length; i++) {
       const song = songs[i];
       if (this.isStringInCaseInsensitiveString(song.title, searchQuery) || song.artist && this.isStringInCaseInsensitiveString(song.artist.name, searchQuery)) {
-        songIndicies.push(i);
+        matchedSongs.push(song);
       }
     }
-    return songIndicies;
+    return matchedSongs;
   }
 
-  private isStringInCaseInsensitiveString(s: string, stringToFind: string) {
+  private isStringInCaseInsensitiveString(s: string, stringToFind: string): boolean {
     return s.toLowerCase().indexOf(stringToFind.toLowerCase()) > -1;
+  }
+
+  sortByOption(songs: Song[], option: string): Song[] {
+    if (option.toLowerCase() === 'newest') {
+      return songs.sort((a, b) => {
+        return (new Date(b.createdAt)).getTime() - (new Date(a.createdAt)).getTime();
+      });
+    } else if (option.toLowerCase() == 'easiest') {
+      return songs.sort((a, b) => {
+        return a.difficultyId - b.difficultyId;
+      });
+    } else if (option.toLowerCase() == 'hardest') {
+      return songs.sort((a, b) => {
+        return b.difficultyId - a.difficultyId;
+      });
+    }
+    return songs;
   }
 }

--- a/src/app/sort/sort.component.spec.ts
+++ b/src/app/sort/sort.component.spec.ts
@@ -31,6 +31,7 @@ describe('SortComponent', () => {
   });
 
   it('should open another component', () => {
+    component.optionSelected.subscribe(d => expect(d).toBe(2));
     expect(component.option).toBe(0);
     expect(sortServiceSpy).not.toHaveBeenCalled();
     openElement.nativeElement.click();


### PR DESCRIPTION
Add the sort functionality to the browse page. Also, stop using song indicies to display on browse page. Just use references to the song objects to display songs.